### PR TITLE
Update linter workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,7 +21,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
-          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' }}
+          VALIDATE_ALL_CODEBASE: |
+            ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           FILTER_REGEX_EXCLUDE: img/.*
 
           VALIDATE_BASH: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' }}
           FILTER_REGEX_EXCLUDE: img/.*
 
           VALIDATE_BASH: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,13 +23,3 @@ jobs:
           DEFAULT_BRANCH: main
           VALIDATE_ALL_CODEBASE: |
             ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-          FILTER_REGEX_EXCLUDE: img/.*
-
-          VALIDATE_BASH: true
-          VALIDATE_BASH_EXEC: true
-          VALIDATE_GITHUB_ACTIONS: true
-          VALIDATE_GITLEAKS: true
-          VALIDATE_JSCPD: true
-          VALIDATE_MARKDOWN: true
-          VALIDATE_SHELL_SHFMT: true
-          VALIDATE_YAML: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,7 @@
 name: Lint code base
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,8 +21,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
-          VALIDATE_ALL_CODEBASE: |
-            ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          VALIDATE_ALL_CODEBASE: false
           FILTER_REGEX_EXCLUDE: img/.*
 
           VALIDATE_BASH: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,4 +20,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
-          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' }}
+          VALIDATE_ALL_CODEBASE: |
+            ${{ github.event_name == 'push' && github.ref_name == 'main' }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2.4.0
-        with:
-          fetch-depth: 0
 
       - name: Lint code base
         uses: github/super-linter/slim@v4.9.0

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,9 +3,8 @@ name: Lint code base
 on:
   push:
     branches:
-      - '**'
-    tags-ignore:
-      - '**'
+      - main
+  pull_request:
 
 jobs:
   lint:
@@ -16,12 +15,14 @@ jobs:
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+
       - name: Lint code base
         uses: github/super-linter/slim@v4.9.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: |
+            ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           FILTER_REGEX_EXCLUDE: img/.*
 
           VALIDATE_BASH: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,5 +20,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
-          VALIDATE_ALL_CODEBASE: |
-            ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
- Trigger on push only if pushing to `main`
- Trigger on default pull request types (opened, closed, synchronize)
- `VALIDATE_ALL_CODEBASE`: `true` for pushes into `main`, `false` else &ndash; should be `false` for PRs and only lint new files / files edited in the PR